### PR TITLE
Use uv run instead of uvx for faster startup

### DIFF
--- a/.agents/skills/daggr/SKILL.md
+++ b/.agents/skills/daggr/SKILL.md
@@ -16,6 +16,10 @@ Full docs: https://raw.githubusercontent.com/gradio-app/daggr/refs/heads/main/RE
 
 ## Quick Start
 
+```bash
+uv init && uv add daggr  # Set up project with daggr
+```
+
 ```python
 from daggr import GradioNode, FnNode, InferenceNode, Graph, ItemList
 import gradio as gr
@@ -170,7 +174,7 @@ def combine(video: str|dict, audio: str|dict) -> str:
 ## Run
 
 ```bash
-uvx --python 3.12 daggr workflow.py &  # Launch in background, hot reloads on file changes
+uv run daggr workflow.py &  # Launch in background, hot reloads on file changes
 ```
 
 ## Authentication


### PR DESCRIPTION
## Summary
- Replace `uvx --python 3.12 daggr` with `uv run daggr` in SKILL.md
- Add setup comment showing `uv init && uv add daggr` for new projects

## Why
`uvx` downloads and installs daggr plus all dependencies (including Gradio) into an isolated temp environment on each run. Using `uv run` with a persistent venv is faster after initial setup since packages are cached locally.